### PR TITLE
Add linkTarget='_blank' for url

### DIFF
--- a/st_chat_message/frontend/components/message.tsx
+++ b/st_chat_message/frontend/components/message.tsx
@@ -51,6 +51,7 @@ function Message({
           <ReactMarkdown
             remarkPlugins={[remarkMath, remarkGfm]}
             rehypePlugins={[rehypeKatex, rehypeRaw]}
+            linkTarget='_blank'
             skipHtml={false}
             remarkRehypeOptions={{
               allowDangerousHtml: true,


### PR DESCRIPTION
Currently if there is url in the message, when user click the url, app will render the html page in current page, after we add `linkTarget='_blank'`, it will open in the new browser tab.